### PR TITLE
Allow svg files to get published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,6 @@ examples
 svg
 node_modules
 screwdriver.yaml
+
+#override so svgs get published
+!dist/svg


### PR DESCRIPTION
#16

Noticed they were missing as I need them for a build i'm doing.

## In this PR:

SVGs were not being published in the package only the sprite svg. This is due to the `.npmignore` line in the file. So I added an override. (tested it works with `npm pack`


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.