### PR TITLE
fix: update ci to node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "font": "rm -rf dist/font && mkdir dist/font && fantasticon -o dist/font -n denali-icons-font -t woff2 -g css --selector .d-icon -p d svg",
     "json": "iconit -n denali-icons --json",
     "sprite": "iconit -n denali-icons --sprite",
-    "svg": "rm -rf dist/svg && mkdir dist/svg && cp -R svg dist"
+    "svg": "rm -rf dist/svg && mkdir dist/svg && cp -R svg dist",
+    "test": "echo SKIP"
   },
   "repository": {
     "type": "git",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ cache:
     pipeline: [~/.npm]
 
 shared:
-    image: node:14
+    image: node:18
 
 jobs:
     main:


### PR DESCRIPTION
## In this PR:

`semantic-release` requires node 18: https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md

---

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.